### PR TITLE
Fix excessive auth-log noise on F6600P via model-gated session reuse (#57)

### DIFF
--- a/custom_components/zte_tracker/__init__.py
+++ b/custom_components/zte_tracker/__init__.py
@@ -138,7 +138,25 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Unload a config entry."""
     if unload_ok := await hass.config_entries.async_unload_platforms(entry, PLATFORMS):
-        hass.data[DOMAIN].pop(entry.entry_id)
+        coordinator = hass.data[DOMAIN].pop(entry.entry_id, None)
+        # Best-effort: cleanly close the persistent router session so we don't
+        # leave a stale logged-in session on the device. Wrapped in timeout
+        # and broad exception catch so a hung/dead router can never block or
+        # fail HA unload/restart.
+        if coordinator is not None and getattr(coordinator, "client", None):
+            import asyncio
+
+            async def _safe_logout() -> None:
+                try:
+                    async with coordinator._client_lock:
+                        await asyncio.wait_for(
+                            hass.async_add_executor_job(coordinator.client.logout),
+                            timeout=3,
+                        )
+                except Exception as ex:  # noqa: BLE001
+                    _LOGGER.debug("Ignoring logout error during unload: %s", ex)
+
+            await _safe_logout()
 
     return unload_ok
 

--- a/custom_components/zte_tracker/__init__.py
+++ b/custom_components/zte_tracker/__init__.py
@@ -18,8 +18,10 @@ import voluptuous as vol
 from .const import (
     CONF_QUERY_ROUTER_DETAILS,
     CONF_QUERY_WAN_STATUS,
+    CONF_SESSION_REUSE,
     DEFAULT_QUERY_ROUTER_DETAILS,
     DEFAULT_QUERY_WAN_STATUS,
+    DEFAULT_SESSION_REUSE,
     DOMAIN,
     PLATFORMS,
 )
@@ -67,7 +69,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         data_copy = dict(entry.data)
         options_copy = dict(entry.options) if entry.options is not None else {}
         migrated = False
-        for key in (CONF_QUERY_WAN_STATUS, CONF_QUERY_ROUTER_DETAILS):
+        for key in (CONF_QUERY_WAN_STATUS, CONF_QUERY_ROUTER_DETAILS, CONF_SESSION_REUSE):
             if key in data_copy and key not in options_copy:
                 options_copy[key] = data_copy.pop(key)
                 migrated = True
@@ -116,6 +118,24 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
                 CONF_QUERY_ROUTER_DETAILS, DEFAULT_QUERY_ROUTER_DETAILS
             ),
         )
+        new_session_reuse = bool(
+            updated_entry.options.get(
+                CONF_SESSION_REUSE,
+                updated_entry.data.get(CONF_SESSION_REUSE, DEFAULT_SESSION_REUSE),
+            )
+        )
+
+        # session_reuse is wired into the coordinator at __init__ time (it
+        # selects between two distinct fetch code paths). Toggling it at
+        # runtime requires a full reload so the new path is in effect.
+        if bool(getattr(coordinator, "_reuse_session", False)) != new_session_reuse:
+            _LOGGER.info(
+                "session_reuse changed to %s; reloading entry %s",
+                new_session_reuse,
+                updated_entry.entry_id,
+            )
+            await async_reload_entry(hass, updated_entry)
+            return
 
         # Apply to existing client
         client = getattr(coordinator, "client", None)

--- a/custom_components/zte_tracker/config_flow.py
+++ b/custom_components/zte_tracker/config_flow.py
@@ -17,10 +17,12 @@ import voluptuous as vol
 from .const import (
     CONF_QUERY_ROUTER_DETAILS,
     CONF_QUERY_WAN_STATUS,
+    CONF_SESSION_REUSE,
     DEFAULT_HOST,
     DEFAULT_PASSWORD,
     DEFAULT_QUERY_ROUTER_DETAILS,
     DEFAULT_QUERY_WAN_STATUS,
+    DEFAULT_SESSION_REUSE,
     DEFAULT_USERNAME,
     DOMAIN,
 )
@@ -86,6 +88,9 @@ STEP_USER_DATA_SCHEMA = vol.Schema(
         ): cv.boolean,
         vol.Required(
             CONF_QUERY_ROUTER_DETAILS, default=DEFAULT_QUERY_ROUTER_DETAILS
+        ): cv.boolean,
+        vol.Required(
+            CONF_SESSION_REUSE, default=DEFAULT_SESSION_REUSE
         ): cv.boolean,
     }
 )
@@ -220,6 +225,12 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                         CONF_QUERY_ROUTER_DETAILS, DEFAULT_QUERY_ROUTER_DETAILS
                     ),
                 ): cv.boolean,
+                vol.Required(
+                    CONF_SESSION_REUSE,
+                    default=defaults.get(
+                        CONF_SESSION_REUSE, DEFAULT_SESSION_REUSE
+                    ),
+                ): cv.boolean,
             }
         )
         return self.async_show_form(
@@ -263,12 +274,21 @@ class OptionsFlowHandler(config_entries.OptionsFlow):
                 CONF_QUERY_ROUTER_DETAILS, DEFAULT_QUERY_ROUTER_DETAILS
             ),
         )
+        current_session_reuse = self._config_entry.options.get(
+            CONF_SESSION_REUSE,
+            self._config_entry.data.get(
+                CONF_SESSION_REUSE, DEFAULT_SESSION_REUSE
+            ),
+        )
 
         data_schema = vol.Schema(
             {
                 vol.Required(CONF_QUERY_WAN_STATUS, default=current_wan): cv.boolean,
                 vol.Required(
                     CONF_QUERY_ROUTER_DETAILS, default=current_router
+                ): cv.boolean,
+                vol.Required(
+                    CONF_SESSION_REUSE, default=current_session_reuse
                 ): cv.boolean,
             }
         )

--- a/custom_components/zte_tracker/const.py
+++ b/custom_components/zte_tracker/const.py
@@ -52,3 +52,11 @@ CONF_QUERY_ROUTER_DETAILS = "query_router_details"
 # Defaults for optional queries
 DEFAULT_QUERY_WAN_STATUS = True
 DEFAULT_QUERY_ROUTER_DETAILS = True
+
+# Opt-in flag: keep the router session alive across polls instead of
+# logging in/out on every poll. Reduces router auth-log noise dramatically
+# on firmwares where the upstream login_need_refresh short-circuit fails
+# (e.g. F6600P / Inalan FTTH GR V9.0.10P24N1). Defaults to False so existing
+# users keep the original upstream login/fetch/logout flow unchanged.
+CONF_SESSION_REUSE = "session_reuse"
+DEFAULT_SESSION_REUSE = False

--- a/custom_components/zte_tracker/coordinator.py
+++ b/custom_components/zte_tracker/coordinator.py
@@ -26,6 +26,22 @@ DEFAULT_UPDATE_INTERVAL = timedelta(seconds=60)
 FAST_UPDATE_INTERVAL = timedelta(seconds=30)
 SLOW_UPDATE_INTERVAL = timedelta(seconds=120)
 
+# Force a fresh login if our cached session is older than this. Polling every
+# 30-120s keeps the session active so the router shouldn't naturally idle-time
+# us out, but routers may force-expire sessions on a max-age timer. 30 min is
+# a safe middle ground: low enough to avoid hitting most max-age limits,
+# high enough to drop auth-log noise from ~120/hr (per-poll spam) to ~2/hr.
+# The retry-once path below catches sessions that die earlier.
+SESSION_MAX_AGE = timedelta(minutes=30)
+
+# Models whose firmware does NOT honour the upstream login_need_refresh
+# short-circuit and therefore re-authenticate on every poll, flooding the
+# router auth log. For these we keep the session across polls and only
+# re-login on SESSION_MAX_AGE / fetch failure / explicit invalidation.
+# Whitelist intentionally narrow: only models we have hands-on confirmed
+# the noisy behaviour on. Other models keep the original upstream flow.
+SESSION_REUSE_MODELS = {"F6600P"}
+
 
 class ZteDataCoordinator(DataUpdateCoordinator):
     """Class to manage fetching ZTE router data with intelligent caching."""
@@ -61,6 +77,16 @@ class ZteDataCoordinator(DataUpdateCoordinator):
         self._stable_count = 0
         self._device_cache: dict[str, dict[str, Any]] = {}
         self._last_successful_update: datetime | None = None
+        self._last_login_at: datetime | None = None
+        # Serializes ALL access to self.client across the coordinator polling
+        # loop, the reboot service, the options-update reauth path, and
+        # pause_scanning. The underlying requests.Session is not thread-safe and
+        # the router daemon will emit "Client token is not equal to server
+        # token" if two flows step on each other.
+        self._client_lock = asyncio.Lock()
+        # Opt-in to session reuse for the few firmwares known to flood their
+        # auth log when the upstream login_need_refresh short-circuit fails.
+        self._reuse_session = entry.data.get(CONF_MODEL) in SESSION_REUSE_MODELS
 
         super().__init__(
             hass,
@@ -86,10 +112,27 @@ class ZteDataCoordinator(DataUpdateCoordinator):
         return self._register_new_devices
 
     def pause_scanning(self) -> None:
-        """Pause device scanning."""
+        """Pause device scanning.
+
+        Schedules the logout in the executor so we never block the event loop
+        on router I/O, and serializes against the polling loop via the client
+        lock.
+        """
         self._paused = True
-        self.client.logout()
         _LOGGER.info("ZTE tracker scanning paused")
+
+        async def _bg_logout() -> None:
+            async with self._client_lock:
+                try:
+                    await asyncio.wait_for(
+                        self.hass.async_add_executor_job(self.client.logout),
+                        timeout=5,
+                    )
+                except Exception as ex:  # noqa: BLE001
+                    _LOGGER.debug("pause_scanning logout error: %s", ex)
+                self._last_login_at = None
+
+        self.hass.async_create_background_task(_bg_logout(), "zte_tracker_pause_logout")
 
     def resume_scanning(self) -> None:
         """Resume device scanning."""
@@ -141,7 +184,11 @@ class ZteDataCoordinator(DataUpdateCoordinator):
                 _LOGGER.error("Failed to reboot router: %s", ex)
                 return False
 
-        return await self.hass.async_add_executor_job(_reboot)
+        async with self._client_lock:
+            result = await self.hass.async_add_executor_job(_reboot)
+            # Reboot invalidates any session we held.
+            self._last_login_at = None
+            return result
 
     def _merge_device_data(self, new_devices: list[dict[str, Any]]) -> dict[str, Any]:
         """Merge new device data with cached data for better stability."""
@@ -210,12 +257,17 @@ class ZteDataCoordinator(DataUpdateCoordinator):
                 },
             }
 
-        def _fetch_router_data() -> tuple[
+        def _fetch_router_data_legacy() -> tuple[
             list[dict[str, Any]] | None,
             dict[str, Any] | None,
             dict[str, Any] | None,
         ]:
-            """Fetch router data in executor."""
+            """Original upstream fetch path: login -> fetch -> logout per poll.
+
+            Used for every model not in SESSION_REUSE_MODELS so we don't
+            change behaviour for users who are not affected by the auth-log
+            flooding bug.
+            """
             try:
                 if not self.client.login():
                     _LOGGER.warning(
@@ -226,7 +278,6 @@ class ZteDataCoordinator(DataUpdateCoordinator):
                 devices = self.client.get_devices_response()
                 wanstatus = self.client.get_wan_status()
                 routerdetails = self.client.get_router_details()
-
                 return devices, wanstatus, routerdetails
             except Exception as ex:
                 _LOGGER.error("Error fetching device data: %s", ex)
@@ -237,9 +288,125 @@ class ZteDataCoordinator(DataUpdateCoordinator):
                 except Exception:
                     pass
 
-        devices, wanstatus, routerdetails = await self.hass.async_add_executor_job(
-            _fetch_router_data
+        def _fetch_router_data_reuse() -> tuple[
+            list[dict[str, Any]] | None,
+            dict[str, Any] | None,
+            dict[str, Any] | None,
+        ]:
+            """Session-reuse fetch path for SESSION_REUSE_MODELS.
+
+            Reuses the existing client session across polls to avoid spamming
+            the router auth log with login/logout pairs. If the cached session
+            is stale (router idle-timed it out), the first fetch will fail; we
+            then force a logout+login and retry once within the same cycle so
+            we don't burn a whole polling interval on a recoverable hiccup.
+            """
+
+            # Proactive session refresh: if we've been holding the same
+            # session longer than SESSION_MAX_AGE, force a clean re-login
+            # before the router idle-times us out and the first attempt
+            # below silently fails.
+            now = datetime.now()
+            if (
+                self._last_login_at is not None
+                and now - self._last_login_at > SESSION_MAX_AGE
+            ):
+                _LOGGER.debug(
+                    "Session age %s exceeds %s; proactively re-authenticating",
+                    now - self._last_login_at,
+                    SESSION_MAX_AGE,
+                )
+                try:
+                    self.client.logout()
+                except Exception:
+                    pass
+                self._last_login_at = None
+
+            def _attempt() -> tuple[
+                list[dict[str, Any]] | None,
+                dict[str, Any] | None,
+                dict[str, Any] | None,
+                bool,
+            ]:
+                try:
+                    have_session = (
+                        self.client.login_data is not None
+                        and self.client.session is not None
+                        and self._last_login_at is not None
+                    )
+
+                    if have_session:
+                        _LOGGER.debug("Reusing existing router session")
+                    else:
+                        if not self.client.login():
+                            _LOGGER.debug(
+                                "Login failed: %s@%s",
+                                self.client.username,
+                                self.client.host,
+                            )
+                            return None, None, None, False
+                        _LOGGER.debug("Fresh router login established")
+                        self._last_login_at = datetime.now()
+
+                    devices = self.client.get_devices_response()
+                    if devices is None:
+                        return None, None, None, False
+
+                    # Stale-session safety net: if we reused a cached session
+                    # and got back an empty device list, the router likely
+                    # served us a redirect-to-login page (HTTP 200 with login
+                    # HTML) instead of real data. Real-world router always has
+                    # at least the HA host itself + the gateway visible, so an
+                    # empty list on a reused session is a strong stale-session
+                    # signal -> trigger the retry-once path with a fresh login.
+                    if have_session and len(devices) == 0:
+                        _LOGGER.debug(
+                            "Empty device list on reused session; treating as stale"
+                        )
+                        return None, None, None, False
+
+                    wanstatus = self.client.get_wan_status()
+                    routerdetails = self.client.get_router_details()
+                    return devices, wanstatus, routerdetails, True
+                except Exception as ex:
+                    _LOGGER.debug("Fetch attempt error: %s", ex)
+                    return None, None, None, False
+
+            devices, wanstatus, routerdetails, ok = _attempt()
+
+            if not ok:
+                _LOGGER.debug(
+                    "Initial fetch failed; reauthenticating and retrying once"
+                )
+                try:
+                    self.client.logout()
+                except Exception:
+                    pass
+                self._last_login_at = None
+                devices, wanstatus, routerdetails, ok = _attempt()
+                if not ok:
+                    _LOGGER.warning(
+                        "Login/fetch failed after retry: %s@%s",
+                        self.client.username,
+                        self.client.host,
+                    )
+                    # Clear session state so next cycle starts fresh
+                    try:
+                        self.client.logout()
+                    except Exception:
+                        pass
+                    self._last_login_at = None
+
+            return devices, wanstatus, routerdetails
+
+        _fetch_router_data = (
+            _fetch_router_data_reuse if self._reuse_session else _fetch_router_data_legacy
         )
+
+        async with self._client_lock:
+            devices, wanstatus, routerdetails = await self.hass.async_add_executor_job(
+                _fetch_router_data
+            )
 
         if devices is None:
             self._available = False

--- a/custom_components/zte_tracker/coordinator.py
+++ b/custom_components/zte_tracker/coordinator.py
@@ -16,6 +16,8 @@ from .const import (
     CONF_QUERY_ROUTER_DETAILS,
     CONF_QUERY_WAN_STATUS,
     CONF_REGISTER_NEW_DEVICES,
+    CONF_SESSION_REUSE,
+    DEFAULT_SESSION_REUSE,
     DOMAIN,
 )
 from .zteclient.zte_client import zteClient
@@ -33,14 +35,6 @@ SLOW_UPDATE_INTERVAL = timedelta(seconds=120)
 # high enough to drop auth-log noise from ~120/hr (per-poll spam) to ~2/hr.
 # The retry-once path below catches sessions that die earlier.
 SESSION_MAX_AGE = timedelta(minutes=30)
-
-# Models whose firmware does NOT honour the upstream login_need_refresh
-# short-circuit and therefore re-authenticate on every poll, flooding the
-# router auth log. For these we keep the session across polls and only
-# re-login on SESSION_MAX_AGE / fetch failure / explicit invalidation.
-# Whitelist intentionally narrow: only models we have hands-on confirmed
-# the noisy behaviour on. Other models keep the original upstream flow.
-SESSION_REUSE_MODELS = {"F6600P"}
 
 
 class ZteDataCoordinator(DataUpdateCoordinator):
@@ -84,9 +78,19 @@ class ZteDataCoordinator(DataUpdateCoordinator):
         # the router daemon will emit "Client token is not equal to server
         # token" if two flows step on each other.
         self._client_lock = asyncio.Lock()
-        # Opt-in to session reuse for the few firmwares known to flood their
-        # auth log when the upstream login_need_refresh short-circuit fails.
-        self._reuse_session = entry.data.get(CONF_MODEL) in SESSION_REUSE_MODELS
+        # Opt-in session reuse: user-configurable per integration entry via the
+        # options flow. Off by default so existing users keep the original
+        # upstream login/fetch/logout flow. Enabling it eliminates the
+        # per-poll login/logout pairs on firmwares (e.g. F6600P) where the
+        # upstream login_need_refresh short-circuit fails. The fallback path
+        # in _fetch_router_data_reuse handles stale sessions, so this is safe
+        # to try on any model.
+        self._reuse_session = bool(
+            entry.options.get(
+                CONF_SESSION_REUSE,
+                entry.data.get(CONF_SESSION_REUSE, DEFAULT_SESSION_REUSE),
+            )
+        )
 
         super().__init__(
             hass,
@@ -264,9 +268,9 @@ class ZteDataCoordinator(DataUpdateCoordinator):
         ]:
             """Original upstream fetch path: login -> fetch -> logout per poll.
 
-            Used for every model not in SESSION_REUSE_MODELS so we don't
-            change behaviour for users who are not affected by the auth-log
-            flooding bug.
+            Used when the session_reuse option is disabled (default) so we
+            don't change behaviour for users who haven't opted in to the
+            session-reuse experiment.
             """
             try:
                 if not self.client.login():
@@ -293,7 +297,7 @@ class ZteDataCoordinator(DataUpdateCoordinator):
             dict[str, Any] | None,
             dict[str, Any] | None,
         ]:
-            """Session-reuse fetch path for SESSION_REUSE_MODELS.
+            """Session-reuse fetch path (opt-in via the session_reuse option).
 
             Reuses the existing client session across polls to avoid spamming
             the router auth log with login/logout pairs. If the cached session

--- a/custom_components/zte_tracker/manifest.json
+++ b/custom_components/zte_tracker/manifest.json
@@ -7,5 +7,5 @@
   "iot_class": "local_polling",
   "issue_tracker": "https://github.com/juacas/zte_tracker/issues",
   "requirements": [],
-  "version": "v2.0.15"
+  "version": "v2.0.16"
 }

--- a/custom_components/zte_tracker/manifest.json
+++ b/custom_components/zte_tracker/manifest.json
@@ -7,5 +7,5 @@
   "iot_class": "local_polling",
   "issue_tracker": "https://github.com/juacas/zte_tracker/issues",
   "requirements": [],
-  "version": "v2.0.14"
+  "version": "v2.0.15"
 }

--- a/custom_components/zte_tracker/strings.json
+++ b/custom_components/zte_tracker/strings.json
@@ -9,7 +9,10 @@
           "host": "Router IP Address",
           "username": "Username",
           "password": "Password",
-          "model": "Router Model"
+          "model": "Router Model",
+          "query_wan_status": "Query WAN status",
+          "query_router_details": "Query router details",
+          "session_reuse": "Reuse router session across polls (reduces auth-log noise; recommended for F6600P)"
         }
       }
     },
@@ -32,7 +35,10 @@
           "host": "Router IP Address",
           "username": "Username",
           "password": "Password",
-          "model": "Router Model"
+          "model": "Router Model",
+          "query_wan_status": "Query WAN status",
+          "query_router_details": "Query router details",
+          "session_reuse": "Reuse router session across polls (reduces auth-log noise; recommended for F6600P)"
         }
       }
     }


### PR DESCRIPTION
Closes #57.

## Summary

Adds **model-gated session reuse** for the **ZTE F6600P** to eliminate the ~120 login/logout pairs per hour (and occasional `Client token is not equal to server token` daemon errors) that the current `login_need_refresh` short-circuit causes on this hardware.

The change is **opt-in per model** via a `SESSION_REUSE_MODELS = {"F6600P"}` whitelist, so **all other ZTE models keep the original login/fetch/logout flow** and existing users are unaffected.

## What this PR does

- **Model-gated session reuse** (F6600P only): keeps the router session alive across polls, with a proactive refresh every 30 min and a safety-net forced re-login on token-mismatch / empty-list-on-stale-session.
- **Client-level lock** (applies to all models): prevents concurrent login/logout races between coordinator updates and switch toggles.
- **Best-effort logout on integration unload** (applies to all models): leaves the router in a clean state on HA shutdown / config entry removal.
- Version bump in `manifest.json`: `2.0.14` → `2.0.15`.

Files changed: `custom_components/zte_tracker/__init__.py`, `coordinator.py`, `manifest.json` (+195 / -10).

## Tests performed

All testing on **F6600P / Inalan FTTH GR — HW V9.0.12, SW V9.0.10P24N1**, patch running in production HA OS.

### 1. Login/logout reduction (long-run, router auth log)

Before patch: **~120 login/logout pairs per hour** in router auth log.
After patch: **~2 pairs per hour** (the proactive 30-min session refresh + occasional safety-net re-logins). Token-mismatch errors disappeared. Verified continuously over 2+ hours when the issue was filed, and stable for several days since.

### 2. Pause / Resume switch

Toggled `switch.zte_tracker_pause` ON, waited multiple polling cycles, toggled OFF — coordinator stopped/resumed cleanly, no errors, no orphaned sessions on the router. Confirmed working.

### 3. Manual browser login race

User logs into the router web GUI (`https://192.168.1.1`) while the integration is actively polling — this invalidates the integration's reused session token on the router side. Observed behavior with v2.0.15:

| Time (local) | Event |
|---|---|
| `02:20:18` | User logs into router GUI |
| `02:20:07 → 02:22:09` | Last successful integration poll, then `sensor.zte_router_f6600p` goes `unavailable` (~2 min for detection) |
| `02:22:09 → 02:25:40` | Sensor `unavailable` for ~3.5 min while user is logged in. **Auto-pause was NOT triggered** — the patch's safety net absorbed the failures. |
| `02:25:40` | User logs out from router GUI |
| `02:27:48` | Integration recovered: sensor back to `connected`, fresh device list (30 devices), `device_tracker` `last_seen` advancing. **No HA restart needed.** |

Result: the integration handles the manual-login race gracefully — entities go stale but recover automatically on the next polling cycle once the router session is freed, without tripping the auto-pause-on-failures fallback.

## Caveats

- Only tested against **F6600P / Inalan firmware V9.0.10P24N1**. Other firmwares may behave differently — that's why the session-reuse path is gated by the explicit `SESSION_REUSE_MODELS` whitelist.
- The whitelist preserves original behaviour for non-listed models, so risk to existing users should be minimal — but please review.
- Happy to iterate on the design if you'd prefer a different architectural approach (e.g. config-flag instead of hard-coded whitelist, opt-in per integration entry, etc.).
