### PR TITLE
fix: clear stale session state on resume after pause

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,7 @@ To control whether newly discovered devices are added as `device_tracker` entiti
 | ZTE F6640     |      F6640      |    ✅    |
 | ZTE F6645P    |     F6645P      |    ✅    |
 | ZTE F680    |      F680      |    ✅    |
+| ZTE F6600P  |     F6600P      |    ✅    |
 | ZTE H169A     |      H169A      |    ✅    |
 | ZTE H2640     |      H2640      |    ✅    |
 | ZTE H288A     |      H288A      |    ✅    |

--- a/custom_components/zte_tracker/coordinator.py
+++ b/custom_components/zte_tracker/coordinator.py
@@ -139,9 +139,21 @@ class ZteDataCoordinator(DataUpdateCoordinator):
         self.hass.async_create_background_task(_bg_logout(), "zte_tracker_pause_logout")
 
     def resume_scanning(self) -> None:
-        """Resume device scanning."""
+        """Resume device scanning.
+
+        Forces a clean client-side session reset so the next poll starts
+        with a fresh login, even if the background logout during pause
+        failed or the router still holds a stale session.
+
+        We only clear login_data (not session) to avoid racing with a
+        background logout that may still be using the session object.
+        The login() method sees login_data=None and calls _setup_session()
+        which safely replaces any stale session.
+        """
         self._paused = False
-        _LOGGER.info("ZTE tracker scanning resumed")
+        self._last_login_at = None
+        self.client.login_data = None
+        _LOGGER.info("ZTE tracker scanning resumed (session state cleared)")
 
     def enable_register_new_devices(self) -> None:
         """Enable automatic registration of new devices."""


### PR DESCRIPTION
## Problem

When the Pause toggle is turned OFF (resume), the integration goes **unavailable** ("API: Unavailable") and never recovers until a full config entry reload.

### Root cause

1. `pause_scanning()` fires a background `_bg_logout()` with a 5-second timeout
2. If the logout times out (common with ZTE routers), `client.login_data` and `client.session` remain set
3. `resume_scanning()` only set `_paused = False` — no session cleanup
4. On the next poll, `login()` sees `login_data is not None` and early-exits with \"Already logged in\" without re-authenticating
5. The subsequent data fetch uses the stale HTTP session and fails → integration goes unavailable

## Fix

Clear `login_data` and `_last_login_at` in `resume_scanning()` so the next poll performs a fresh login via `_setup_session()`.

We intentionally do **not** close the `session` object to avoid racing with the background logout task that may still hold a reference to it — `_setup_session()` safely replaces it and the old session gets GCed.

## Testing

- Reproduced on ZTE F6600P with HA 2025.x
- Verified: pause → unpause → integration reconnects within one poll interval
- Without fix: pause → unpause → permanent \"API: Unavailable\" until config entry reload