### PR TITLE
fix: code review quick wins (issue #68, items 1-8)

### DIFF
--- a/custom_components/zte_tracker/__init__.py
+++ b/custom_components/zte_tracker/__init__.py
@@ -97,8 +97,9 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     # Set up all platforms
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
 
-    # Register all services
-    setup_services(hass)
+    # Register services (once per domain, not per entry)
+    if not hass.services.has_service(DOMAIN, "reboot"):
+        setup_services(hass)
 
     # Register an update listener to apply option changes at runtime
     async def _async_options_updated(

--- a/custom_components/zte_tracker/button.py
+++ b/custom_components/zte_tracker/button.py
@@ -1,12 +1,12 @@
 """Button platform for ZTE Tracker to reboot the router."""
 from __future__ import annotations
 
-from typing import Any
 import logging
 
 from homeassistant.components.button import ButtonEntity
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
@@ -51,6 +51,12 @@ class ZteRebootButton(CoordinatorEntity, ButtonEntity):
         try:
             success = await self.coordinator.async_reboot_router()
             if not success:
-                _LOGGER.error("Router reboot failed for host: %s", host)
+                raise HomeAssistantError(
+                    f"Router reboot failed for host: {host}"
+                )
+        except HomeAssistantError:
+            raise
         except Exception as exc:  # pragma: no cover - defensive logging
-            _LOGGER.exception("Exception while rebooting router %s: %s", host, exc)
+            raise HomeAssistantError(
+                f"Exception while rebooting router {host}: {exc}"
+            ) from exc

--- a/custom_components/zte_tracker/config_flow.py
+++ b/custom_components/zte_tracker/config_flow.py
@@ -196,8 +196,6 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                     # Check if already configured
                     await self.async_set_unique_id(user_input[CONF_HOST])
                     self._abort_if_unique_id_configured()
-                    # Optionally, add statusmsg to entry data for diagnostics
-                    user_input["statusmsg"] = info.get("statusmsg", "")
                     return self.async_create_entry(title=info["title"], data=user_input)
 
         defaults = user_input or {}

--- a/custom_components/zte_tracker/coordinator.py
+++ b/custom_components/zte_tracker/coordinator.py
@@ -447,7 +447,7 @@ class ZteDataCoordinator(DataUpdateCoordinator):
 
                     return devices, wanstatus, routerdetails, True
                 except Exception as ex:
-                    _LOGGER.debug("Fetch attempt error: %s", ex)
+                    _LOGGER.debug("Fetch attempt error: %s", ex, exc_info=True)
                     return None, None, None, False
 
             devices, wanstatus, routerdetails, ok = _attempt()

--- a/custom_components/zte_tracker/sensor.py
+++ b/custom_components/zte_tracker/sensor.py
@@ -44,7 +44,6 @@ class ZteBaseSensor(CoordinatorEntity, SensorEntity):
             name=f"ZTE Router {coordinator.client.host}",
             manufacturer="ZTE",
             model=coordinator.client.model,
-            sw_version=coordinator.client.model,
         )
 
 
@@ -70,9 +69,8 @@ class ZteRouterSensor(ZteBaseSensor):
         """Return the state attributes."""
         data = self.coordinator.data or {}
         router_info = data.get("router_info", {})
-        # Get local time in local timezone.
-        router_info["last_update"] = ha_dt.now().isoformat()
-        return router_info
+        # Return a copy to avoid mutating shared coordinator.data
+        return {**router_info, "last_update": ha_dt.now().isoformat()}
 
 
 class ZteDeviceCountSensor(ZteBaseSensor):

--- a/custom_components/zte_tracker/zteclient/zte_client.py
+++ b/custom_components/zte_tracker/zteclient/zte_client.py
@@ -24,8 +24,10 @@ from urllib3.util.retry import Retry
 
 from ..const import DEFAULT_QUERY_ROUTER_DETAILS, DEFAULT_QUERY_WAN_STATUS
 
-# Suppress InsecureRequestWarning globally
-warnings.simplefilter("ignore", InsecureRequestWarning)
+# Suppress InsecureRequestWarning only from urllib3 (not globally)
+warnings.filterwarnings(
+    "ignore", category=InsecureRequestWarning, module=r"urllib3\.connectionpool"
+)
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -718,20 +720,23 @@ class zteClient:
             _LOGGER.warning(f"Failed to fetch WAN status: {ex}")
         return wan_attrs
 
+    _SENSITIVE_HEADERS = frozenset({"cookie", "authorization", "set-cookie"})
+
     def log_request(self, r):
-        # Get cookie value for debugging.
+        """Log request details, filtering sensitive headers."""
         if not r or not r.request:
             return
-        # sid = self.session.cookies.get('SID_HTTPS_')
-
+        safe_headers = {
+            k: v
+            for k, v in r.request.headers.items()
+            if k.lower() not in self._SENSITIVE_HEADERS
+        }
         _LOGGER.debug(
             "Request %d URL: %s Headers: %s",
             r.status_code,
             r.request.url,
-            dict(r.request.headers),
+            safe_headers,
         )
-        # Don't log response content in debug to avoid potential security issues
-        # _LOGGER.debug("Response status: %d", r.status_code)
 
     def parse_devices(
         self,


### PR DESCRIPTION
Addresses the 8 quick-win items from #68 that were approved in [this comment](https://github.com/juacas/zte_tracker/issues/68#issuecomment-4471412897).

### Changes

| # | File | Fix |
|---|------|-----|
| 1 | `sensor.py` | `extra_state_attributes` no longer mutates shared `coordinator.data` — returns a shallow copy |
| 2 | `button.py` | Reboot failures now raise `HomeAssistantError` so the HA UI surfaces the error |
| 3 | `config_flow.py` | Transient `statusmsg` no longer persisted in `entry.data` |
| 4 | `__init__.py` | Services registered once per domain, not re-registered per entry |
| 5 | `zte_client.py` | Debug logs filter out `Cookie`/`Authorization`/`Set-Cookie` headers |
| 6 | `zte_client.py` | `InsecureRequestWarning` suppression scoped to `urllib3.connectionpool` (was global) |
| 7 | `sensor.py` | Removed misleading `sw_version` (`model` field already carries the model name) |
| 8 | `coordinator.py` | Reuse-fetch exceptions now log full traceback at debug level (`exc_info=True`) |

### Testing

- All `.py` files pass `py_compile`
- All JSON files (`manifest.json`, `strings.json`, `hacs.json`) validate
- No functional changes to device tracking or config flow logic

Closes #68
